### PR TITLE
Add info about conference time zone

### DIFF
--- a/index.md
+++ b/index.md
@@ -167,14 +167,14 @@ The room in the venue and the link will be shared here, once available.
 <script>
   var x = setInterval(function() {
     var d = new Date();
-    var n = d.toLocaleTimeString("en-US", {timeZone: "America/Chicago", hour: '2-digit', minute:'2-digit', hour12: false})
+    var n = d.toLocaleTimeString("en-US", {timeZone: "America/Detroit", hour: '2-digit', minute:'2-digit', hour12: false})
     document.getElementById("centraltime").innerHTML = n
   }, 1000);
 </script>
 
 This full day workshop will take place on Thursday Oct 5th, 8:30 am to 5:30 pm EDT. [ICS-file](assets/TAM-Workshop.ics).
 
-Below times are in EDT. Current time is <span id="centraltime"></span>.
+Below times are in Detroit time. Current time in Detroit is <span id="centraltime"></span>.
 
 {% include schedule %}
 

--- a/index.md
+++ b/index.md
@@ -167,12 +167,13 @@ The room in the venue and the link will be shared here, once available.
 <script>
   var x = setInterval(function() {
     var d = new Date();
-    var n = d.toLocaleTimeString("en-US", {timeZone: "EDT", hour: '2-digit', minute:'2-digit', hour12: false})
+    var n = d.toLocaleTimeString("en-US", {timeZone: "America/Chicago", hour: '2-digit', minute:'2-digit', hour12: false})
     document.getElementById("centraltime").innerHTML = n
   }, 1000);
 </script>
 
 This full day workshop will take place on Thursday Oct 5th, 8:30 am to 5:30 pm EDT. [ICS-file](assets/TAM-Workshop.ics).
+
 Below times are in EDT. Current time is <span id="centraltime"></span>.
 
 {% include schedule %}

--- a/index.md
+++ b/index.md
@@ -163,7 +163,17 @@ The room in the venue and the link will be shared here, once available.
 
 ## Agenda (tentative)
 
+<!-- script to display conference time -->
+<script>
+  var x = setInterval(function() {
+    var d = new Date();
+    var n = d.toLocaleTimeString("en-US", {timeZone: "EDT", hour: '2-digit', minute:'2-digit', hour12: false})
+    document.getElementById("centraltime").innerHTML = n
+  }, 1000);
+</script>
+
 This full day workshop will take place on Thursday Oct 5th, 8:30 am to 5:30 pm EDT. [ICS-file](assets/TAM-Workshop.ics).
+Below times are in EDT. Current time is <span id="centraltime"></span>.
 
 {% include schedule %}
 

--- a/index.md
+++ b/index.md
@@ -172,7 +172,7 @@ The room in the venue and the link will be shared here, once available.
   }, 1000);
 </script>
 
-This full day workshop will take place on Thursday Oct 5th, 8:30 am to 5:30 pm EDT. [ICS-file](assets/TAM-Workshop.ics).
+This full day workshop will take place on Thursday Oct 5th, 08:30 to 17:30 EDT. [ICS-file](assets/TAM-Workshop.ics).
 
 Below times are in Detroit time. Current time in Detroit is <span id="centraltime"></span>.
 


### PR DESCRIPTION
Displays for example:

> This full day workshop will take place on Thursday Oct 5th, 08:30 to 17:30 EDT. [ICS-file](https://agents4ad.github.io/assets/TAM-Workshop.ics).
> 
> Below times are in Detroit time. Current time in Detroit is 15:57.